### PR TITLE
fix some DM issues

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -374,18 +374,6 @@ export const createNote = async (body, cw, inReplyTo, toUser) => {
         cc = [];
         directMessage = true;
 
-        // TODO: need to make sure we don't create dup tags
-        // // tag this person as mentioned even if they aren't
-        // this will cause the DM to show up in the DM window in Mastodon
-        // const uname = ActivityPub.getUsername(parent.attributedTo);
-        // const account = await fetchUser(parent.attributedTo);
-
-        // tags.push({
-        //   "type": "Mention",
-        //   "href": account.actor.url,
-        //   "name": `@${ uname }`
-        // });
-
       } else {
         cc.push(parent.attributedTo);
       }
@@ -426,6 +414,24 @@ export const createNote = async (body, cw, inReplyTo, toUser) => {
       }
     }
   }
+
+  // if this is a DM, require a mention of the recipient
+  if (directMessage) {
+    const account = await fetchUser(to[0]);
+    const uname = ActivityPub.getUsername(to[0]);
+
+    if (!tags.some((t) => t.href === account.actor.url)) {
+      const link = `<span class="h-card"><a href="${account.actor.url}" class=\"u-url mention\">@<span>${uname}</span></a></span>`;
+      processedContent = link + ' ' + processedContent;
+
+      tags.push({
+          "type": "Mention",
+          "href": account.actor.url,
+          "name": `@${ uname }`
+      });
+    }
+  }
+
 
   const content = md.render(processedContent);
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -264,10 +264,8 @@ router.get('/dms/:handle?', async (req, res) => {
                 }
             });
 
-            // find last incoming message
-            lastIncoming = inbox.slice().find((message) => {
-                return message.attributedTo != ActivityPub.actor.id;
-            });
+            // find last message in thread
+            lastIncoming = inbox.length ? inbox[0] : null;
 
             // mark all of these messages as seen
             if (inboxIndex[recipient.id]) {


### PR DESCRIPTION
fix for #35  and #36  improvements to DM for consistency with Mastodon behavior.

outbound DMs will always have a mention of the recipient.
outbound DMs should be a reply to the most recent message in the thread, regardless of who authored it.