### PR TITLE
fix pagination bugs

### DIFF
--- a/design/dashboard.handlebars
+++ b/design/dashboard.handlebars
@@ -27,14 +27,18 @@
     {{/if}}
 </div>
 
+
+{{#if next}}
 <a href="/private?offset={{next}}" class="moreLink">More</a>
+{{/if}}
 </div>
 {{> peopleTools}}
 <script>
     // take note of the most recent post date
-    {{#each activitystream}} {{#if @first}} 
+    {{#isEq offset "0"}}
+    {{#each ../activitystream}} {{#if @first}} 
     app.latestPost("{{or this.boost.published this.note.published}}");
-     {{/if}}{{/each}}
-   
+    {{/if}}{{/each}}
+    {{/isEq}}
     app.pollForPosts();
 </script>

--- a/design/notifications.handlebars
+++ b/design/notifications.handlebars
@@ -3,7 +3,6 @@
     <span>🔔 Notifications</span>
     <a href="/private/notifications" id="newNotifications" class="unread" hidden></a>
 </header>
-
 {{#each notifications}}
     <div class="activity">
     {{#with this}}
@@ -33,13 +32,20 @@
     {{/with}}
     </div>
 {{/each}}
+
+{{#if next}}
+<a href="/private/notifications?offset={{next}}" class="moreLink">More</a>
+{{/if}}
+
 </div>
 {{> peopleTools}}
 <script>
     // take note of the most recent post date
-    {{#each notifications}} {{#if @first}} 
+    {{#isEq offset "0"}}
+    {{#each ../notifications}} {{#if @first}} 
     app.latestNotification("{{this.time}}");
      {{/if}}{{/each}}
+     {{/isEq}}
    
     app.pollForPosts();
 </script>

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const hbs = create({
       if (str && str.includes('image')) return options.fn(this);
     },
     isEq: (a, b, options) => {
-      if (a === b) return options.fn(this);
+      if (a == b) return options.fn(this);
     },
     or: (a, b, options) => {
       return a || b

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -146,10 +146,12 @@ router.get('/', async (req, res) => {
     const likes = await getLikes();
     const boosts = await getBoosts();
     const offset = parseInt(req.query.offset) || 0;
+    const pageSize = 20;
+
     const {
         activitystream,
         next
-    } = await getActivityStream(10, offset);
+    } = await getActivityStream(pageSize, offset);
 
     const notes = await Promise.all(activitystream.map(async (n) => {
         // handle boosted posts
@@ -190,7 +192,8 @@ router.get('/', async (req, res) => {
         res.render('dashboard', {
             layout: 'private',
             me: ActivityPub.actor,
-            next: next,
+            offset: offset, 
+            next: notes.length == pageSize ? next : null,
             activitystream: notes,
             followers: followers,
             following: following,
@@ -202,7 +205,10 @@ router.get('/', async (req, res) => {
 
 router.get('/notifications', async (req, res) => {
     const likes = await getLikes();
-    const notifications = await Promise.all(getNotifications().map(async (notification) => {
+    const offset = parseInt(req.query.offset) || 0;
+    const pageSize = 20;
+    const notes = getNotifications().slice().reverse().slice(offset, offset+pageSize);
+    const notifications = await Promise.all(notes.map(async (notification) => {
         const {
             actor
         } = await fetchUser(notification.notification.actor);
@@ -247,7 +253,9 @@ router.get('/notifications', async (req, res) => {
     res.render('notifications', {
         layout: 'private',
         me: ActivityPub.actor,
-        notifications: notifications.filter((n)=>n!==null).reverse(),
+        offset: offset,
+        next: notifications.length == pageSize ? offset + notifications.length : null,
+        notifications: notifications.filter((n)=>n!==null),
         followersCount: followers.length,
         followingCount: following.length
     });


### PR DESCRIPTION
Multiple pagination changes:

- adds pagination to the notifications page. should improve perf.  now 20 per page. fix #81 
- increase homepage to 20 posts instead of 10.
- add some logic so you next button will not be present if no more posts exist
- fix #23 lastread cookie only updated when you are on the first page