### PR TITLE
Verify the domain name in .env is a well-formatted domain name on boot

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -640,6 +640,12 @@ export const removeFollower = async (follower) => {
 }
 
 export const ensureAccount = async (name, domain) => {
+  // verify domain name
+  const re = new RegExp(/^((?:(?:(?:\w[\.\-\+]?)*)\w)+)((?:(?:(?:\w[\.\-\+]?){0,62})\w)+)\.(\w{2,6})$/);
+  if(!domain.match(re)) {
+    console.error('Domain name from .evn "' + domain + '" does not appear to be a well-formatted domain name.');
+    process.exit(1);
+  }
   return new Promise((resolve, reject) => {
     if (existsSync(accountFile)) {
       resolve(getAccount());


### PR DESCRIPTION
When setting up a new instance, you want the domain-name that's specified in .env to be well-formatted before generating the local config data files.
