### PR TITLE
Fix sensitive flag always being true

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -501,7 +501,7 @@ export const createNote = async (body, cw, inReplyTo, toUser, editOf) => {
     "to": to,
     "cc": cc,
     directMessage,
-    "sensitive": cw !== null ? true : false,
+    "sensitive": cw ? true : false,
     "atomUri": activityId,
     "inReplyToAtomUri": null,
     "content": content,


### PR DESCRIPTION
When no cw field is given, cw is 'undefined' not null. The sensitive flag was always being set.
Most clients don't care if there's no actual summary field.
elk.zone does care and shows the fold for all shuttlecraft posts.