### PR TITLE
Feature: Outbound requests are now queued and delivered in the background

### DIFF
--- a/design/prefs.handlebars
+++ b/design/prefs.handlebars
@@ -1,5 +1,19 @@
 {{> peopleTools}}
 <div class="box">
+    <header>Outbound Queue</header>
+    <div style="padding: 1rem;">
+        {{#isEq queue.state 0}}✅{{/isEq}}
+        {{#isEq queue.state 1}}🟢{{/isEq}}
+        {{#isEq queue.state 3}}🔴{{/isEq}}
+        {{#if queue.size}}
+            {{#if queue.shouldRun}}Running.{{/if}}
+            {{queue.size}} items remain.
+        {{else}}
+            Queue empty
+        {{/if}}
+    </div>
+</div>
+<div class="box">
     <header>Preferences</header>
     <form method="post" action="/private/prefs">
         <fieldset>

--- a/design/public/home.handlebars
+++ b/design/public/home.handlebars
@@ -51,8 +51,8 @@
                     {{/if}}
                     {{{content}}}
 
-                    {{#if note.inReplyTo}}
-                    <p><a href="{{note.inReplyTo}}" class="showThread">Show Thread</a></p>
+                    {{#if this.inReplyTo}}
+                    <p><a href="{{this.inReplyTo}}" class="showThread">Show Thread</a></p>
                     {{/if}}
 
                     {{#each note.attachment}}

--- a/lib/ActivityPub.js
+++ b/lib/ActivityPub.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import crypto from 'crypto';
 import debug from 'debug';
+import { queue } from './queue.js';
 const logger = debug('ActivityPub');
 
 /**
@@ -105,58 +106,57 @@ export class ActivityPubClient {
    * @returns a fetch result
    */
   async send(recipient, message) {
-    let url;
-    try {
-      url = new URL(recipient.inbox);
-    } catch (err) {
-      console.error('INVALID INBOX URL', recipient);
-      throw err;
-    }
-    const inboxFragment = url.pathname;
-
-    const digestHash = crypto.createHash('sha256').update(JSON.stringify(message)).digest('base64');
-    const signer = crypto.createSign('sha256');
-    const d = new Date();
-    const stringToSign = `(request-target): post ${inboxFragment}\nhost: ${
-      url.hostname
-    }\ndate: ${d.toUTCString()}\ndigest: SHA-256=${digestHash}`;
-    signer.update(stringToSign);
-    signer.end();
-    const signature = signer.sign(this.account.privateKey);
-    const signatureB64 = signature.toString('base64');
-    const header = `keyId="${this.actor.publicKey.id}",headers="(request-target) host date digest",signature="${signatureB64}"`;
-
-    logger('OUTBOUND TO ', recipient.inbox);
-    logger('MESSAGE', message);
-
-    const controller = new AbortController();
-    setTimeout(() => controller.abort(), 5000);
-
-    const res = await fetch(
-      recipient.inbox,
-      {
-        headers: {
-          Host: url.hostname,
-          'Content-type': 'application/json',
-          Date: d.toUTCString(),
-          Digest: `SHA-256=${digestHash}`,
-          Signature: header
-        },
-        method: 'POST',
-        json: true,
-        body: JSON.stringify(message),
-        signal: controller.signal
-      },
-      function (error, response) {
-        if (error) {
-          console.error('Error sending outbound message:', error, response);
-        } else {
-          logger('Response', response.status);
-        }
+    queue.enqueue(() => {
+      let url;
+      try {
+        url = new URL(recipient.inbox);
+      } catch (err) {
+        console.error('INVALID INBOX URL', recipient);
+        throw err;
       }
-    );
+      const inboxFragment = url.pathname;
 
-    return res;
+      const digestHash = crypto.createHash('sha256').update(JSON.stringify(message)).digest('base64');
+      const signer = crypto.createSign('sha256');
+      const d = new Date();
+      const stringToSign = `(request-target): post ${inboxFragment}\nhost: ${
+        url.hostname
+      }\ndate: ${d.toUTCString()}\ndigest: SHA-256=${digestHash}`;
+      signer.update(stringToSign);
+      signer.end();
+      const signature = signer.sign(this.account.privateKey);
+      const signatureB64 = signature.toString('base64');
+      const header = `keyId="${this.actor.publicKey.id}",headers="(request-target) host date digest",signature="${signatureB64}"`;
+
+      logger('OUTBOUND TO ', recipient.inbox);
+      logger('MESSAGE', message);
+
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 10000);
+      return fetch(
+        recipient.inbox,
+        {
+          headers: {
+            Host: url.hostname,
+            'Content-type': 'application/json',
+            Date: d.toUTCString(),
+            Digest: `SHA-256=${digestHash}`,
+            Signature: header
+          },
+          method: 'POST',
+          json: true,
+          body: JSON.stringify(message),
+          signal: controller.signal
+        },
+        function (error, response) {
+          if (error) {
+            console.error('Error sending outbound message:', error, response);
+          } else {
+            logger('Response', response.status);
+          }
+        }
+      );
+    });
   }
 
   /**

--- a/lib/ActivityPub.js
+++ b/lib/ActivityPub.js
@@ -175,7 +175,7 @@ export class ActivityPubClient {
       object: post.id
     };
 
-    await ActivityPub.send(recipient, message);
+    ActivityPub.send(recipient, message);
 
     // return the guid to make this undoable.
     return message;
@@ -201,7 +201,7 @@ export class ActivityPubClient {
         object: post.id
       }
     };
-    await ActivityPub.send(recipient, message);
+    ActivityPub.send(recipient, message);
     return message;
   }
 
@@ -219,7 +219,7 @@ export class ActivityPubClient {
       actor: this.actor.id,
       object: recipient.id
     };
-    await ActivityPub.send(recipient, message);
+    ActivityPub.send(recipient, message);
 
     // return the guid to make this undoable.
     return message;
@@ -244,7 +244,7 @@ export class ActivityPubClient {
         object: recipient.id
       }
     };
-    await ActivityPub.send(recipient, message);
+    ActivityPub.send(recipient, message);
 
     // return the guid to make this undoable.
     return message;
@@ -263,7 +263,7 @@ export class ActivityPubClient {
       actor: this.actor.id,
       object: followRequest
     };
-    await ActivityPub.send(recipient, message);
+    ActivityPub.send(recipient, message);
 
     return message;
   }
@@ -285,12 +285,7 @@ export class ActivityPubClient {
       to: object.to,
       cc: object.cc
     };
-    try {
-      await ActivityPub.send(recipient, message);
-    } catch (err) {
-      // TODO: retry
-      console.error('Failed to deliver outbound message', err);
-    }
+    ActivityPub.send(recipient, message);
     return message;
   }
 
@@ -311,12 +306,7 @@ export class ActivityPubClient {
       to: object.to,
       cc: object.cc
     };
-    try {
-      await ActivityPub.send(recipient, message);
-    } catch (err) {
-      // TODO: retry
-      console.error('Failed to deliver outbound message', err);
-    }
+    ActivityPub.send(recipient, message);
     return message;
   }
 
@@ -348,10 +338,10 @@ export class ActivityPubClient {
     };
 
     // deliver outbound messages to all recipients
-    recipients.forEach(async recipient => {
+    recipients.forEach(recipient => {
       // if the recipient is "my followers", send it to them
       if (recipient === this.actor.followers) {
-        followers.forEach(async follower => {
+        followers.forEach(follower => {
           ActivityPub.send(follower, message);
         });
       } else {
@@ -395,10 +385,10 @@ export class ActivityPubClient {
     };
 
     // deliver outbound messages to all recipients
-    recipients.forEach(async recipient => {
+    recipients.forEach(recipient => {
       // if the recipient is "my followers", send it to them
       if (recipient === this.actor.followers) {
-        followers.forEach(async follower => {
+        followers.forEach(follower => {
           ActivityPub.send(follower, message);
         });
       } else {

--- a/lib/account.js
+++ b/lib/account.js
@@ -509,7 +509,6 @@ export const createNote = async (body, cw, inReplyTo, toUser, editOf) => {
 
     const inIndex = INDEX.findIndex(idx => idx.id === object.id);
     if (inIndex < 0) {
-      console.log('pushing ne post to index!');
       INDEX.push({
         type: 'note', // someone else
         id: object.id,

--- a/lib/account.js
+++ b/lib/account.js
@@ -344,26 +344,37 @@ export const getNote = async id => {
 
 export const sendCreateToFollowers = async object => {
   const followers = await getFollowers();
-  followers.forEach(async follower => {
-    const account = await fetchUser(follower);
-    try {
-      ActivityPub.sendCreate(account.actor, object);
-    } catch (err) {
-      // TODO: should retry
-      console.error('Failed to deliver outbound post', err);
-    }
+  const actors = await Promise.all(
+    followers.map(async follower => {
+      try {
+        const account = await fetchUser(follower);
+        return account.actor;
+      } catch (err) {
+        console.error('Could not fetch follower', err);
+      }
+    })
+  );
+
+  actors.forEach(async actor => {
+    ActivityPub.sendCreate(actor, object);
   });
 };
+
 export const sendUpdateToFollowers = async object => {
   const followers = await getFollowers();
-  followers.forEach(async follower => {
-    const account = await fetchUser(follower);
-    try {
-      ActivityPub.sendUpdate(account.actor, object);
-    } catch (err) {
-      // TODO: should retry
-      console.error('Failed to deliver outbound post', err);
-    }
+  const actors = await Promise.all(
+    followers.map(async follower => {
+      try {
+        const account = await fetchUser(follower);
+        return account.actor;
+      } catch (err) {
+        console.error('Could not fetch follower', err);
+      }
+    })
+  );
+
+  actors.forEach(async actor => {
+    ActivityPub.sendUpdate(actor, object);
   });
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -8,10 +8,10 @@ import debug from 'debug';
 const logger = debug('ono:queue');
 
 export const queue = new Queue({
-  //   concurrent: 4,
-  //   interval: 250
-  concurrent: 1,
-  interval: 2000
+  concurrent: 4,
+  interval: 250
+  //   concurrent: 1,
+  //   interval: 2000
 });
 
 queue.on('start', () => logger('QUEUE STARTING'));

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,0 +1,37 @@
+/**
+ * This is a VERY BASIC implementation of a queue for outgoing requests.
+ * This separates the sending of the messages, which could take a while, require retries, etc from the response to the server or UI.
+ */
+
+import Queue from 'queue-promise';
+import debug from 'debug';
+const logger = debug('ono:queue');
+
+export const queue = new Queue({
+  //   concurrent: 4,
+  //   interval: 250
+  concurrent: 1,
+  interval: 2000
+});
+
+queue.on('start', () => logger('QUEUE STARTING'));
+queue.on('stop', () => logger('QUEUE STOPPING'));
+queue.on('end', () => logger('QUEUE ENDING'));
+queue.on('dequeue', () => logger('DEQUEUING!', queue.size));
+
+queue.on('resolve', data => {
+  if (data.url) {
+    logger(`SEND STATUS ${data.status} ${data.statusText} FOR  ${data.url} `);
+  } else {
+    logger(data);
+  }
+});
+queue.on('reject', error => console.error(error));
+
+while (queue.shouldRun) {
+  try {
+    await queue.dequeue();
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,10 @@
         "md5": "^2.3.0",
         "moment": "^2.29.4",
         "node-fetch": "^3.3.0",
+        "queue-promise": "^2.2.1",
         "rss-generator": "^0.0.3"
       },
       "devDependencies": {
-        "djlint": "^1.19.11",
         "eslint": "^8.32.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-config-standard": "^17.0.0",
@@ -527,49 +527,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -745,20 +702,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/djlint": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/djlint/-/djlint-1.19.13.tgz",
-      "integrity": "sha512-4Z5/Eb6lzHaDK4QST6gTx1KfYQ55iKCLckE1L4eLTaHKdHOiXF6PW4veuWwy/dqyA2gfIqV56AdPSH5iXhU2eA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "python-shell": "^3.0.1",
-        "yargs": "17.6.2"
-      },
-      "bin": {
-        "djlint": "bin/index.js"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "dev": true,
@@ -889,15 +832,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -1630,15 +1564,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2958,15 +2883,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/python-shell": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-3.0.1.tgz",
-      "integrity": "sha512-TWeotuxe1auhXa5bGRScxnc2J+0r41NBntSa6RYZtMBLtAEsvCboKrEbW6DvASosWQepVkhZZlT3B5Ei766G+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/qs": {
       "version": "6.11.0",
       "license": "BSD-3-Clause",
@@ -2998,6 +2914,14 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/queue-promise": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/queue-promise/-/queue-promise-2.2.1.tgz",
+      "integrity": "sha512-C3eyRwLF9m6dPV4MtqMVFX+Xmc7keZ9Ievm3jJ/wWM5t3uVbFnGsJXwpYzZ4LaIEcX9bss/mdaKzyrO6xheRuA==",
+      "engines": {
+        "node": ">=8.12.0"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -3044,15 +2968,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -3812,15 +3727,6 @@
       "version": "1.0.1",
       "license": "MIT"
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "dev": true,
@@ -3832,62 +3738,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {
@@ -4211,42 +4061,6 @@
         "string-width": "^5.0.0"
       }
     },
-    "cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
-      }
-    },
     "color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -4346,16 +4160,6 @@
     "destroy": {
       "version": "1.2.0"
     },
-    "djlint": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/djlint/-/djlint-1.19.13.tgz",
-      "integrity": "sha512-4Z5/Eb6lzHaDK4QST6gTx1KfYQ55iKCLckE1L4eLTaHKdHOiXF6PW4veuWwy/dqyA2gfIqV56AdPSH5iXhU2eA==",
-      "dev": true,
-      "requires": {
-        "python-shell": "^3.0.1",
-        "yargs": "17.6.2"
-      }
-    },
     "doctrine": {
       "version": "3.0.0",
       "dev": true,
@@ -4446,12 +4250,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
     },
     "escape-html": {
       "version": "1.0.3"
@@ -4937,12 +4735,6 @@
     },
     "functions-have-names": {
       "version": "1.2.3",
-      "dev": true
-    },
-    "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-intrinsic": {
@@ -5680,12 +5472,6 @@
       "version": "2.2.0",
       "dev": true
     },
-    "python-shell": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-3.0.1.tgz",
-      "integrity": "sha512-TWeotuxe1auhXa5bGRScxnc2J+0r41NBntSa6RYZtMBLtAEsvCboKrEbW6DvASosWQepVkhZZlT3B5Ei766G+Q==",
-      "dev": true
-    },
     "qs": {
       "version": "6.11.0",
       "requires": {
@@ -5695,6 +5481,11 @@
     "queue-microtask": {
       "version": "1.2.3",
       "dev": true
+    },
+    "queue-promise": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/queue-promise/-/queue-promise-2.2.1.tgz",
+      "integrity": "sha512-C3eyRwLF9m6dPV4MtqMVFX+Xmc7keZ9Ievm3jJ/wWM5t3uVbFnGsJXwpYzZ4LaIEcX9bss/mdaKzyrO6xheRuA=="
     },
     "range-parser": {
       "version": "1.2.1"
@@ -5719,12 +5510,6 @@
     },
     "regexpp": {
       "version": "3.2.0",
-      "dev": true
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "resolve": {
@@ -6186,64 +5971,12 @@
     "xml": {
       "version": "1.0.1"
     },
-    "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true
-    },
     "yallist": {
       "version": "4.0.0",
       "dev": true
     },
     "yaml": {
       "version": "2.2.1",
-      "dev": true
-    },
-    "yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
-      "dev": true,
-      "requires": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "dependencies": {
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -43,11 +43,12 @@
     "express-basic-auth": "^1.1.5",
     "express-handlebars": "^6.0.6",
     "glob": "^8.0.3",
+    "husky": "^8.0.3",
     "markdown-it": "^13.0.1",
     "md5": "^2.3.0",
-    "husky": "^8.0.3",
     "moment": "^2.29.4",
     "node-fetch": "^3.3.0",
+    "queue-promise": "^2.2.1",
     "rss-generator": "^0.0.3"
   },
   "devDependencies": {

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -21,6 +21,7 @@ import {
 import { fetchUser } from '../lib/users.js';
 import { getPrefs, INDEX, searchKnownUsers, updatePrefs } from '../lib/storage.js';
 import { ActivityPub } from '../lib/ActivityPub.js';
+import { queue } from '../lib/queue.js';
 export const router = express.Router();
 const logger = debug('ono:admin');
 
@@ -551,6 +552,11 @@ router.get('/prefs', (req, res) => {
   res.render('prefs', {
     layout: 'private',
     url: '/prefs',
+    queue: {
+      size: queue.size,
+      state: queue.state,
+      shouldRun: queue.shouldRun
+    },
     prefs: getPrefs(),
     me: ActivityPub.actor,
     followersCount: followers.length,


### PR DESCRIPTION
Resolves #26 
Supercedes #121 

This PR introduces a very simple queue to handle the outbound HTTP requests to remote inboxes. This applies to posts, edits, boosts, follows, etc. 

Starting with 4 workers and a 250ms interval between dequeues. Seems reasonable.

Errors to the outbound messages continue to emit to stderr