### PR TITLE
fix #133 - properly show boosts in strangers feed (and follows!)

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -278,7 +278,11 @@ router.get('/feeds/:handle?', async (req, res) => {
               })
               .map(async post => {
                 try {
-                  return getFullPostDetails(post.object);
+                  if (post.type === 'Create') {
+                    return getFullPostDetails(post.object);
+                  } else {
+                    return getFullPostDetails(post);
+                  }
                 } catch (err) {
                   console.error('error while loading post from remote outbox', err);
                 }
@@ -683,6 +687,7 @@ router.get('/lookup', async (req, res) => {
 router.post('/follow', async (req, res) => {
   const handle = req.body.handle;
   if (handle) {
+    logger('toggle follow', handle);
     if (handle === req.app.get('account').actor.id) {
       return res.status(200).json({
         isFollowed: false
@@ -692,7 +697,7 @@ router.post('/follow', async (req, res) => {
     if (actor) {
       const status = isFollowing(actor.id);
       if (!status) {
-        // const message = await ActivityPub.sendFollow(actor);
+        ActivityPub.sendFollow(actor);
 
         return res.status(200).json({
           isFollowed: true


### PR DESCRIPTION
This fixes a bug where boosted posts didn't have their proper attribution and showed up as if posted by the booster.

Also, this re-enables follows. DOH!