### PR TITLE
public.js: add https to site for RSS feed.

### DIFF
--- a/routes/public.js
+++ b/routes/public.js
@@ -126,7 +126,7 @@ router.get('/feed', async (req, res) => {
 
   const feed = new RSS({
     title: `${USERNAME}@${DOMAIN}`,
-    site_url: DOMAIN,
+    site_url: "https://" + DOMAIN, // validator requires full protocol
     pubDate: posts[0].published
   });
 


### PR DESCRIPTION
Trivial addition to add protocol for the RSS feed and keep the W3C Feed Validator happy(/-ier)